### PR TITLE
Add note about file limits not being raised on systemd distros

### DIFF
--- a/README.esync
+++ b/README.esync
@@ -20,6 +20,16 @@ have a reasonable limit.) To raise the limit you'll want to edit
 
 then restart your session.
 
+On distributions using systemd, the settings in `/etc/security/limits.conf` will
+be overridden by systemd's own settings. If you run `ulimit -Hn` and it returns
+a lower number than the one you've previously set then you can set
+
+DefaultLimitNOFILE=100000
+
+in both `/etc/systemd/system.conf` and `/etc/systemd/user.conf`. You can then
+execute `sudo systemctl daemon-reexec` and restart your session. Check again
+with `ulimit -Hn` that the limit is correct.
+
 Also note that if the wineserver has esync active, all clients also must, and
 vice versa. Otherwise things will probably crash quite badly.
 


### PR DESCRIPTION
I had a hard time figuring this one out so might as well document it. After I had it working, I got some nice improvements with esync, pretty much double the FPS in Far Cry 3 :+1: 